### PR TITLE
making data envelope in _queueData consistent.

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -68,7 +68,12 @@ static NSString *QUEUE_HAS_MESSAGE = @"__WVJB_QUEUE_MESSAGE__";
 }
 
 - (void)_queueData:(NSDictionary *)data responseCallback:(WVJBResponseCallback)responseCallback handlerName:(NSString*)handlerName {
-    NSMutableDictionary* message = [NSMutableDictionary dictionaryWithObject:data forKey:@"data"];
+    NSMutableDictionary* message;
+	if ([data objectForKey:@"responseId"]) {
+	        message = [NSMutableDictionary dictionaryWithDictionary:data];
+	} else {
+	        message = [NSMutableDictionary dictionaryWithObject:data forKey:@"data"];
+	}
     
     if (responseCallback) {
         NSString* callbackId = [NSString stringWithFormat:@"objc_cb_%d", ++_uniqueId];


### PR DESCRIPTION
There was a discrepency between the data envelope resulting from sends and sends coming from responseCallback.

While normal sends had their data wrapped in a data object message = { data : { "sendData" : sendData } }, sends coming from a responseCallback already had a data object that was being wrapped again in a data object, i.e. 
message = {data : {"responseID" : responseId, "data" : data}};

This was causing bugs with the javascript functions. Had to add logic to make sure that data and responseId are always at the root level of the message object.

There may be a better/more consistent way of accomplishing this, but this seemed to be a way to fix the bugs I was having without having to touch to many other functions. 
