### PR TITLE
Fixes crashes on callbacks from JS 

### DIFF
--- a/WebViewJavascriptBridge.podspec
+++ b/WebViewJavascriptBridge.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "WebViewJavascriptBridge"
+  s.version      = "2.1.1"
+  s.summary      = "A standalone iOS class for sending messages to and from javascript in a UIWebView."
+  s.homepage     = "http://github.com/marcuswestin/WebViewJavascriptBridge"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "marcuswestin" => "marcus.westin@gmail.com" }
+  s.source       = { :git => "https://github.com/marcuswestin/WebViewJavascriptBridge.git", :tag => "2.1.1" }
+  s.platform     = :ios, "4.2"
+  s.source_files = "WebViewJavascriptBridge/WebViewJavascriptBridge.{h,m}"
+  s.resource     = "WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt"
+  s.framework    = "UIKit"
+  s.dependency     "JSONKit"
+end

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -69,7 +69,7 @@ static bool logging = false;
 }
 
 - (void)registerHandler:(NSString *)handlerName handler:(WVJBHandler)handler {
-    [self.messageHandlers setObject:handler forKey:handlerName];
+    [self.messageHandlers setObject:[handler copy] forKey:handlerName];
 }
 
 - (void)reset {
@@ -83,7 +83,7 @@ static bool logging = false;
     
     if (responseCallback) {
         NSString* callbackId = [NSString stringWithFormat:@"objc_cb_%d", ++_uniqueId];
-        [self.responseCallbacks setObject:responseCallback forKey:callbackId];
+        [self.responseCallbacks setObject:[responseCallback copy] forKey:callbackId];
         [message setObject:callbackId forKey:@"callbackId"];
     }
 


### PR DESCRIPTION
Blocks not copied when saved in lists inside bridge. That leads to
crash on callback from JS because callback block doesn't exist at that
moment.
