### PR TITLE
Inject javascript after all other resources load

### DIFF
--- a/WebViewJavascriptBridge_iOS/WebViewJavascriptBridge_iOS.m
+++ b/WebViewJavascriptBridge_iOS/WebViewJavascriptBridge_iOS.m
@@ -23,14 +23,13 @@
     [bridge reset];
     
     [webView setDelegate:bridge];
-    
-    bridge.numRequestsLoading = 0;
-    
+        
     return bridge;
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     if (webView != self.webView) { return; }
+    
     self.numRequestsLoading--;
     
     if (self.numRequestsLoading == 0 && ![[self.webView stringByEvaluatingJavaScriptFromString:@"typeof WebViewJavascriptBridge == 'object'"] isEqualToString:@"true"]) {


### PR DESCRIPTION
The -webViewDidFinishLoad method is called after _each_ file--html, css, js--is loaded. So right now the bridge javascript is injected every time a new file is loaded, beginning with the initial HTML file. This means there's a chance the bridge javascript is executed before all other javascript is loaded.

The solution is to keep a counter for the number of resources loading, using the -webViewDidStartLoad and -webViewDidFinish/FailLoad methods to keep the counter in sync.

I didn't test the OS X implementation, but it works on iOS.
