### PR TITLE
Added possibility to set custom bundle where core WebViewJavascriptBridge.js script is located.

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.h
@@ -29,6 +29,7 @@ typedef void (^WVJBHandler)(id data, WVJBResponseCallback responseCallback);
 
 + (instancetype)bridgeForWebView:(WVJB_WEBVIEW_TYPE*)webView handler:(WVJBHandler)handler;
 + (instancetype)bridgeForWebView:(WVJB_WEBVIEW_TYPE*)webView webViewDelegate:(WVJB_WEBVIEW_DELEGATE_TYPE*)webViewDelegate handler:(WVJBHandler)handler;
++ (instancetype)bridgeForWebView:(WVJB_WEBVIEW_TYPE*)webView webViewDelegate:(WVJB_WEBVIEW_DELEGATE_TYPE*)webViewDelegate handler:(WVJBHandler)handler resourceBundle:(NSBundle*)bundle;
 + (void)enableLogging;
 
 - (void)send:(id)message;


### PR DESCRIPTION
I added new field and new initialization method to be able to set custom NSBundle where `WebViewJavascriptBridge.js.txt` file is located. 

I'm developing a static library which uses `WebViewJavascriptBride` and I need to export all resources somehow. With CocoaPods it is easy but if I want to build an `.a` library file I need to export all resources to `Resources.bundle` and place it next to `.h` header files. It would be nice if I could just pass additional argument with this bundle so that `WebViewJavascriptBridge` can find it's dependencies there :)

If you find it helpful feel free to merge it to your repo. I tried not to make any needless changes.
