### PR TITLE
Escape U+2028 and U+2029 when writing JSON as a JavaScript string literal

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -135,6 +135,8 @@ static bool logging = false;
     messageJSON = [messageJSON stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
     messageJSON = [messageJSON stringByReplacingOccurrencesOfString:@"\r" withString:@"\\r"];
     messageJSON = [messageJSON stringByReplacingOccurrencesOfString:@"\f" withString:@"\\f"];
+    messageJSON = [messageJSON stringByReplacingOccurrencesOfString:@"\u2028" withString:@"\\u2028"];
+    messageJSON = [messageJSON stringByReplacingOccurrencesOfString:@"\u2029" withString:@"\\u2029"];
 
     NSString* javascriptCommand = [NSString stringWithFormat:@"WebViewJavascriptBridge._handleMessageFromObjC('%@');", messageJSON];
     if ([[NSThread currentThread] isMainThread]) {


### PR DESCRIPTION
U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are not allowed in a JavaScript string literal, though they are valid JSON. Trying to send a message with either causes an "unexpected EOF" exception on the JavaScript side. [Here](http://timelessrepo.com/json-isnt-a-javascript-subset)'s a relevant blog post on the issue.

You can test this by doing something like `[_bridge send:@"A string sent\u2028 from ObjC to JS" responseCallback:nil]`.
