### PR TITLE
Fix crash when callback called more than once

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -167,8 +167,10 @@ static bool logging = false;
         NSString* responseId = message[@"responseId"];
         if (responseId) {
             WVJBResponseCallback responseCallback = _responseCallbacks[responseId];
-            responseCallback(message[@"responseData"]);
-            [_responseCallbacks removeObjectForKey:responseId];
+            if (responseCallback) {
+                responseCallback(message[@"responseData"]);
+                [_responseCallbacks removeObjectForKey:responseId];
+            }
         } else {
             WVJBResponseCallback responseCallback = NULL;
             NSString* callbackId = message[@"callbackId"];


### PR DESCRIPTION
Callbacks should not be called more than once. However if they are, we
can throw out the subsequent calls, rather than crashing the app.
