### PR TITLE
Implemented timeouts.

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.h
@@ -35,9 +35,11 @@ typedef void (^WVJBHandler)(id data, WVJBResponseCallback responseCallback);
 
 - (void)send:(id)message;
 - (void)send:(id)message responseCallback:(WVJBResponseCallback)responseCallback;
+- (void)send:(id)message timeoutInMillis:(NSUInteger)timeout responseCallback:(WVJBResponseCallback)responseCallback;
 - (void)registerHandler:(NSString*)handlerName handler:(WVJBHandler)handler;
 - (void)callHandler:(NSString*)handlerName;
 - (void)callHandler:(NSString*)handlerName data:(id)data;
 - (void)callHandler:(NSString*)handlerName data:(id)data responseCallback:(WVJBResponseCallback)responseCallback;
+- (void)callHandler:(NSString*)handlerName data:(id)data timeoutInMillis:(NSUInteger)timeout responseCallback:(WVJBResponseCallback)responseCallback;
 
 @end


### PR DESCRIPTION
I believe timeout functionality would be a useful feature for this library. When interacting with a website, especially in a mobile context where internet connection is not guaranteed, there can be some causes where you can call a handler and never receive a callback.

This PR fixes that problem, allowing the bridge to return a timeout error as the response callback. This ensures that for every call into a webview that expects a callback, it will always get one.