### PR TITLE
Warn if/when deallocated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To use a WebViewJavascriptBridge in your own project:
 		responseCallback(@"Right back atcha");
 	}];
 
+Please note that you need to save the instance of the bridge to a variable that does not goes out of scope (an instance variable in your ViewController e.g.). Otherwise the bridge will be garbage collected.
+
 4) Go ahead and send some messages from ObjC to javascript:
 
 	[bridge send:@"Well hello there"];

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -245,6 +245,7 @@ static bool logging = false;
 }
 
 - (void) _platformSpecificDealloc {
+    NSLog(@"WebViewJavascriptBridge: WARNING: Deallocated");
     _webView.frameLoadDelegate = nil;
     _webView.resourceLoadDelegate = nil;
     _webView.policyDelegate = nil;
@@ -334,6 +335,7 @@ static bool logging = false;
 }
 
 - (void) _platformSpecificDealloc {
+    NSLog(@"WebViewJavascriptBridge: WARNING: Deallocated");
     _webView.delegate = nil;
 }
 


### PR DESCRIPTION
I just tracked an error when the Bridge instance was deallocated since I had not assigned it to a instance variable in my ViewController. I guess other might also fall into this trap (should it not be retained when setting itself as the delegate? Oh well) and so at least we can log the dealloc.