### PR TITLE
Feature/unsafe for alert speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ WebViewJavascriptBridge is used by a range of companies and projects. This list 
 - Dojo4's [Imbed](http://dojo4.github.io/imbed/)
 - [CareZone](https://carezone.com)
 - [Hemlig](http://www.hemlig.co)
+- [BrowZine](http://thirdiron.com/browzine/)
 
 Setup & Examples (iOS & OSX)
 ----------------------------
@@ -150,6 +151,15 @@ Example:
 		NSLog(@"Current UIWebView page URL is: %@", responseData);
 	}];
 
+##### `[bridge disableJavscriptAlertBoxSafetyTimeout:(BOOL)isDisabled]`
+
+Disable the use of setTimeout when sending a message across the bridge. It is only safe to disable this timeout if you do not call any of the javascript popup box functions (alert, confirm, and prompt). If you call one of these functions from the bridged javascript code, the app will hang. When this setTimeout call is not used, there can be a significant decrease in the amount of time it takes to send and receive messages across the bridge.
+
+Example:
+
+	[self.bridge disableJavscriptAlertBoxSafetyTimeout:YES];
+
+
 #### Custom bundle
 `WebViewJavascriptBridge` requires `WebViewJavascriptBridge.js.txt` file that is injected into web view to create a bridge on JS side. Standard implementation uses `mainBundle` to search for this file. If you e.g. build a static library and you have that file placed somewhere else you can use this method to specify which bundle should be searched for `WebViewJavascriptBridge.js.txt` file:
 
@@ -181,11 +191,13 @@ Example:
 		// Start using the bridge
 	}, false)
 
-##### `bridge.init(function messageHandler(data, response) { ... })`
+##### `bridge.init(function messageHandler(data, response) { ... }, disableAlertSafety)`
 
 Initialize the bridge. This should be called inside of the `'WebViewJavascriptBridgeReady'` event handler.
 
 The `messageHandler` function will receive all messages sent from ObjC via `[bridge send:(id)data]` and `[bridge send:(id)data responseCallback:(WVJBResponseCallback)responseCallback]`.
+
+The `disableAlertSafety` parameter has the same effect as calling `[bridge disableJavscriptAlertBoxSafetyTimeout:(BOOL)isDisabled]`.
 
 The `response` object will be defined if if ObjC sent the message with a `WVJBResponseCallback` block.
 

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.h
@@ -39,5 +39,6 @@ typedef void (^WVJBHandler)(id data, WVJBResponseCallback responseCallback);
 - (void)callHandler:(NSString*)handlerName;
 - (void)callHandler:(NSString*)handlerName data:(id)data;
 - (void)callHandler:(NSString*)handlerName data:(id)data responseCallback:(WVJBResponseCallback)responseCallback;
+- (void)disableJavscriptAlertBoxSafetyTimeout:(BOOL)isDisabled;
 
 @end

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
@@ -10,6 +10,8 @@
 	
 	var responseCallbacks = {}
 	var uniqueId = 1
+
+	var disableDispatchTimeout = false
 	
 	function _createQueueReadyIframe(doc) {
 		messagingIframe = doc.createElement('iframe')
@@ -18,9 +20,10 @@
 		doc.documentElement.appendChild(messagingIframe)
 	}
 
-	function init(messageHandler) {
+	function init(messageHandler, disableAlertSafety) {
 		if (WebViewJavascriptBridge._messageHandler) { throw new Error('WebViewJavascriptBridge.init called twice') }
 		WebViewJavascriptBridge._messageHandler = messageHandler
+        _disableJavscriptAlertBoxSafetyTimeout(disableAlertSafety)
 		var receivedMessages = receiveMessageQueue
 		receiveMessageQueue = null
 		for (var i=0; i<receivedMessages.length; i++) {
@@ -40,11 +43,18 @@
 		_doSend({ handlerName:handlerName, data:data }, responseCallback)
 	}
 	
+    function _disableJavscriptAlertBoxSafetyTimeout(safetyDisabled) {
+        if (safetyDisabled !== undefined) {
+            disableDispatchTimeout = safetyDisabled
+        }
+    }
+
 	function _doSend(message, responseCallback) {
 		if (responseCallback) {
 			var callbackId = 'cb_'+(uniqueId++)+'_'+new Date().getTime()
 			responseCallbacks[callbackId] = responseCallback
 			message['callbackId'] = callbackId
+            message['startTime'] = Date.now()
 		}
 		sendMessageQueue.push(message)
 		messagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://' + QUEUE_HAS_MESSAGE
@@ -57,38 +67,47 @@
 	}
 
 	function _dispatchMessageFromObjC(messageJSON) {
-		setTimeout(function _timeoutDispatchMessageFromObjC() {
-			var message = JSON.parse(messageJSON)
-			var messageHandler
-			var responseCallback
+		if (disableDispatchTimeout) {
+			_executeMessageFromObjC(messageJSON)
+		}
+		else {
+			setTimeout(function _timeoutDispatchMessageFromObjC() {
+				_executeMessageFromObjC(messageJSON)
+			}, 0)
+		}
+	}
 
-			if (message.responseId) {
-				responseCallback = responseCallbacks[message.responseId]
-				if (!responseCallback) { return; }
-				responseCallback(message.responseData)
-				delete responseCallbacks[message.responseId]
-			} else {
-				if (message.callbackId) {
-					var callbackResponseId = message.callbackId
-					responseCallback = function(responseData) {
-						_doSend({ responseId:callbackResponseId, responseData:responseData })
-					}
-				}
-				
-				var handler = WebViewJavascriptBridge._messageHandler
-				if (message.handlerName) {
-					handler = messageHandlers[message.handlerName]
-				}
-				
-				try {
-					handler(message.data, responseCallback)
-				} catch(exception) {
-					if (typeof console != 'undefined') {
-						console.log("WebViewJavascriptBridge: WARNING: javascript handler threw.", message, exception)
-					}
+    function _executeMessageFromObjC(messageJSON) {
+		var message = JSON.parse(messageJSON)
+		var messageHandler
+
+		if (message.responseId) {
+			var responseCallback = responseCallbacks[message.responseId]
+			if (!responseCallback) { return; }
+			responseCallback(message.responseData)
+			delete responseCallbacks[message.responseId]
+		} else {
+			var responseCallback
+			if (message.callbackId) {
+				var callbackResponseId = message.callbackId
+				responseCallback = function(responseData) {
+					_doSend({ responseId:callbackResponseId, responseData:responseData })
 				}
 			}
-		})
+
+			var handler = WebViewJavascriptBridge._messageHandler
+			if (message.handlerName) {
+				handler = messageHandlers[message.handlerName]
+			}
+
+			try {
+				handler(message.data, responseCallback)
+			} catch(exception) {
+				if (typeof console != 'undefined') {
+					console.log("WebViewJavascriptBridge: WARNING: javascript handler threw.", message, exception)
+				}
+			}
+		}
 	}
 	
 	function _handleMessageFromObjC(messageJSON) {
@@ -104,6 +123,7 @@
 		send: send,
 		registerHandler: registerHandler,
 		callHandler: callHandler,
+        _disableJavscriptAlertBoxSafetyTimeout: _disableJavscriptAlertBoxSafetyTimeout,
 		_fetchQueue: _fetchQueue,
 		_handleMessageFromObjC: _handleMessageFromObjC
 	}

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
@@ -80,14 +80,14 @@
     function _executeMessageFromObjC(messageJSON) {
 		var message = JSON.parse(messageJSON)
 		var messageHandler
+		var responseCallback
 
 		if (message.responseId) {
-			var responseCallback = responseCallbacks[message.responseId]
+			responseCallback = responseCallbacks[message.responseId]
 			if (!responseCallback) { return; }
 			responseCallback(message.responseData)
 			delete responseCallbacks[message.responseId]
 		} else {
-			var responseCallback
 			if (message.callbackId) {
 				var callbackResponseId = message.callbackId
 				responseCallback = function(responseData) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.js.txt
@@ -23,7 +23,7 @@
 	function init(messageHandler, disableAlertSafety) {
 		if (WebViewJavascriptBridge._messageHandler) { throw new Error('WebViewJavascriptBridge.init called twice') }
 		WebViewJavascriptBridge._messageHandler = messageHandler
-        _disableJavscriptAlertBoxSafetyTimeout(disableAlertSafety)
+        _disableJavascriptAlertBoxSafetyTimeout(disableAlertSafety)
 		var receivedMessages = receiveMessageQueue
 		receiveMessageQueue = null
 		for (var i=0; i<receivedMessages.length; i++) {
@@ -43,7 +43,7 @@
 		_doSend({ handlerName:handlerName, data:data }, responseCallback)
 	}
 	
-    function _disableJavscriptAlertBoxSafetyTimeout(safetyDisabled) {
+    function _disableJavascriptAlertBoxSafetyTimeout(safetyDisabled) {
         if (safetyDisabled !== undefined) {
             disableDispatchTimeout = safetyDisabled
         }
@@ -123,7 +123,7 @@
 		send: send,
 		registerHandler: registerHandler,
 		callHandler: callHandler,
-        _disableJavscriptAlertBoxSafetyTimeout: _disableJavscriptAlertBoxSafetyTimeout,
+        _disableJavascriptAlertBoxSafetyTimeout: _disableJavascriptAlertBoxSafetyTimeout,
 		_fetchQueue: _fetchQueue,
 		_handleMessageFromObjC: _handleMessageFromObjC
 	}

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -78,6 +78,19 @@ static bool logging = false;
     _messageHandlers[handlerName] = [handler copy];
 }
 
+- (void)disableJavscriptAlertBoxSafetyTimeout:(BOOL)isDisabled {
+    NSString* javascriptCommand = [NSString stringWithFormat:@"WebViewJavascriptBridge._disableJavscriptAlertBoxSafetyTimeout(%@);", isDisabled ? @"true" : @"false"];
+    
+    if ([[NSThread currentThread] isMainThread]) {
+        [_webView stringByEvaluatingJavaScriptFromString:javascriptCommand];
+    } else {
+        __strong WVJB_WEBVIEW_TYPE* strongWebView = _webView;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [strongWebView stringByEvaluatingJavaScriptFromString:javascriptCommand];
+        });
+    }
+}
+
 /* Platform agnostic internals
  *****************************/
 


### PR DESCRIPTION
This change allows WebViewJavascriptBridge to send messages across the bridge without using `setTimeout`.  This can lead to a significant performance improvement for the time it takes to send a message to and get a response from the Javascript code.  I have observed at least a 10x improvement in many of my calls.  However, it also makes the app hang if you use pop-up windows from the Javascript code.  Therefore, this feature is only turned on if `[self.bridge disableJavscriptAlertBoxSafetyTimeout:YES]` is called or the `disableAlertSafety` flag on `bridge.init` is set to true.