### PR TITLE
remove numRequestsLoading

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -19,10 +19,6 @@
     WVJB_WEAK id _webViewDelegate;
     long _uniqueId;
     WebViewJavascriptBridgeBase *_base;
-#if defined WVJB_PLATFORM_IOS
-    NSUInteger _numRequestsLoading;
-#endif
-    
 }
 
 /* API
@@ -187,10 +183,9 @@
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
+	
     
-    _numRequestsLoading--;
-    
-    if (_numRequestsLoading == 0 && ![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
+    if ( ![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
         [_base injectJavascriptFile:YES];
     }
     [_base dispatchStartUpMessageQueue];
@@ -204,8 +199,7 @@
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     if (webView != _webView) { return; }
-    
-    _numRequestsLoading--;
+	
     
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
@@ -234,8 +228,7 @@
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
-    
-    _numRequestsLoading++;
+	
     
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -18,11 +18,7 @@
     WVJB_WEAK WVJB_WEBVIEW_TYPE* _webView;
     WVJB_WEAK id _webViewDelegate;
     long _uniqueId;
-    WebViewJavascriptBridgeBase *_base;
-#if defined WVJB_PLATFORM_IOS
-	NSUInteger _numRequestsLoading;
-#endif
-}
+    WebViewJavascriptBridgeBase *_base;}
 
 /* API
  *****/
@@ -186,9 +182,8 @@
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
-	_numRequestsLoading--;
     
-    if ( _numRequestsLoading <= 0 && ![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
+    if (![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
         [_base injectJavascriptFile:YES];
     }
     [_base dispatchStartUpMessageQueue];
@@ -203,8 +198,6 @@
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     if (webView != _webView) { return; }
 	
-	_numRequestsLoading--;
-    //watch error code 101
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
         [strongDelegate webView:webView didFailLoadWithError:error];
@@ -232,7 +225,6 @@
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
-	_numRequestsLoading++;
     
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -19,6 +19,9 @@
     WVJB_WEAK id _webViewDelegate;
     long _uniqueId;
     WebViewJavascriptBridgeBase *_base;
+#if defined WVJB_PLATFORM_IOS
+	NSUInteger _numRequestsLoading;
+#endif
 }
 
 /* API
@@ -183,9 +186,9 @@
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
-	
+	_numRequestsLoading--;
     
-    if ( ![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
+    if ( _numRequestsLoading <= 0 && ![[webView stringByEvaluatingJavaScriptFromString:[_base webViewJavascriptCheckCommand]] isEqualToString:@"true"]) {
         [_base injectJavascriptFile:YES];
     }
     [_base dispatchStartUpMessageQueue];
@@ -200,7 +203,8 @@
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     if (webView != _webView) { return; }
 	
-    
+	_numRequestsLoading--;
+    //watch error code 101
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
         [strongDelegate webView:webView didFailLoadWithError:error];
@@ -228,7 +232,7 @@
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
     if (webView != _webView) { return; }
-	
+	_numRequestsLoading++;
     
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -12,6 +12,7 @@
     id _webViewDelegate;
     long _uniqueId;
     NSBundle *_resourceBundle;
+	
 }
 
 static bool logging = false;


### PR DESCRIPTION
This counter should be removed.
This counter can be blocked into an inconsistent state that will stop the library from functioning.
This state can be encountered because of an error 101.
