### PR TITLE
Fix a webview cannot be loaded when the page need redirect.

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -102,8 +102,11 @@
     _base.numRequestsLoading--;
     
     if (_base.numRequestsLoading == 0) {
+        NSString *url = [webView.URL absoluteString];
         [webView evaluateJavaScript:[_base webViewJavascriptCheckCommand] completionHandler:^(NSString *result, NSError *error) {
-            [_base injectJavascriptFile:![result boolValue]];
+            if([[webView.URL absoluteString] isEqualToString:url]) {
+                [_base injectJavascriptFile:![result boolValue]];
+            }
         }];
     }
     


### PR DESCRIPTION
When load a page which need redirect, that will be blank.
To compare the url, don`t inject frame that js need to redirect.