### PR TITLE
Print a log instead raising an exception in @select(flushMessageQueue:)

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -108,7 +108,8 @@ static int logMaxLength = 500;
             }
             
             if (!handler) {
-                [NSException raise:@"WVJBNoHandlerException" format:@"No handler for message from JS: %@", message];
+                NSLog(@"WVJBNoHandlerException, No handler for message from JS: %@", message);
+                continue;
             }
             
             handler(message[@"data"], responseCallback);


### PR DESCRIPTION
If raise an exception in @select(flushMessageQueue:), it will be raising to WebView Call stack through @select(webView:decidePolicyForNavigationAction:decisionHandler:).

Sometimes It will cause memory leaks on devices (not on simulators), and the WebView will not be release as soon as possible.

Bad idea to throw an exception there!