### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ setupWebViewJavascriptBridge(function(bridge) {
 		console.log("JS Echo called with:", data)
 		responseCallback(data)
 	})
-	bridge.callHandler('ObjC Echo', function responseCallback(responseData) {
+	bridge.callHandler('ObjC Echo', {'key':'value'}, function responseCallback(responseData) {
 		console.log("JS received response:", responseData)
 	})
 })


### PR DESCRIPTION
Edited README example to make sure that the JavaScript callHandler (in #5) is able to send data to the objective-c registerHandler (in #3).  This is for the handler "ObjC Echo."