### PR TITLE
Fix WKNavigationDelegate methods in ExampleApp-iOS

### DIFF
--- a/Example Apps/ExampleApp-iOS/ExampleUIWebViewController.m
+++ b/Example Apps/ExampleApp-iOS/ExampleUIWebViewController.m
@@ -24,6 +24,7 @@
     [WebViewJavascriptBridge enableLogging];
     
     _bridge = [WebViewJavascriptBridge bridgeForWebView:webView];
+    [_bridge setWebViewDelegate:self];
     
     [_bridge registerHandler:@"testObjcCallback" handler:^(id data, WVJBResponseCallback responseCallback) {
         NSLog(@"testObjcCallback called: %@", data);

--- a/Example Apps/ExampleApp-iOS/ExampleWKWebViewController.m
+++ b/Example Apps/ExampleApp-iOS/ExampleWKWebViewController.m
@@ -25,6 +25,7 @@
     [self.view addSubview:webView];
     [WKWebViewJavascriptBridge enableLogging];
     _bridge = [WKWebViewJavascriptBridge bridgeForWebView:webView];
+    [_bridge setWebViewDelegate:self];
     
     [_bridge registerHandler:@"testObjcCallback" handler:^(id data, WVJBResponseCallback responseCallback) {
         NSLog(@"testObjcCallback called: %@", data);
@@ -37,11 +38,11 @@
     [self loadExamplePage:webView];
 }
 
-- (void)webViewDidStartLoad:(UIWebView *)webView {
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
     NSLog(@"webViewDidStartLoad");
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView {
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     NSLog(@"webViewDidFinishLoad");
 }
 


### PR DESCRIPTION
- fix `WKNavigationDelegate` method name
- set `ExampleWKWebViewController` as `WKNavigationDelegate`
- set `ExampleUIWebViewController` as `UIWebViewDelegate` in example