### PR TITLE
Fix unwanted stopLoading when the web is still fetching page.

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -127,7 +127,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
         } else {
             [_base logUnkownMessage:url];
         }
-        [webView stopLoading];
+        decisionHandler(WKNavigationActionPolicyCancel);
     }
     
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {


### PR DESCRIPTION
once there is a web `request 1`, response 200 and the the page is only for
submit form data, we call the submit request `request 2`, if the WebViewJavascriptBridge js inject effect  before the `request 2` response, it result
`[webView stopLoading]` task to stop the `request 2`