### PR TITLE
Add default completion handler for authentication challenge

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -113,6 +113,8 @@
     __strong typeof(_webViewDelegate) strongDelegate = _webViewDelegate;
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:didReceiveAuthenticationChallenge:completionHandler:)]) {
         [strongDelegate webView:webView didReceiveAuthenticationChallenge:challenge completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 }
 


### PR DESCRIPTION
If no _webViewDelegate exists an exception occurs that the completion handler is not called. This handles that case with a default completion.

Thanks!
