### PR TITLE
Change the bridge URLs so that they can be used in a CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ function setupWebViewJavascriptBridge(callback) {
 	window.WVJBCallbacks = [callback];
 	var WVJBIframe = document.createElement('iframe');
 	WVJBIframe.style.display = 'none';
-	WVJBIframe.src = 'https://__bridge_loaded__';
+	WVJBIframe.src = 'https://wvjb-bridge_loaded';
 	document.documentElement.appendChild(WVJBIframe);
 	setTimeout(function() { document.documentElement.removeChild(WVJBIframe) }, 0)
 }

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.h
@@ -9,8 +9,8 @@
 
 #define kOldProtocolScheme @"wvjbscheme"
 #define kNewProtocolScheme @"https"
-#define kQueueHasMessage   @"__wvjb_queue_message__"
-#define kBridgeLoaded      @"__bridge_loaded__"
+#define kQueueHasMessage   @"wvjb-queue-message"
+#define kBridgeLoaded      @"wvjb-bridge-loaded"
 
 typedef void (^WVJBResponseCallback)(id responseData);
 typedef void (^WVJBHandler)(id data, WVJBResponseCallback responseCallback);

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
@@ -38,7 +38,7 @@ NSString * WebViewJavascriptBridge_js() {
 	var messageHandlers = {};
 	
 	var CUSTOM_PROTOCOL_SCHEME = 'https';
-	var QUEUE_HAS_MESSAGE = '__wvjb_queue_message__';
+	var QUEUE_HAS_MESSAGE = 'wvjb-queue-message';
 	
 	var responseCallbacks = {};
 	var uniqueId = 1;


### PR DESCRIPTION
The previous URLs contained leading/middle/trailing underscores, which are illegal to use as 'host-char' in a Content-Security-Policy.

Changing them to hyphens makes WebViewJavascriptBridge compatible with solutions requiring a CSP.

This pull request fixes issue #263.