### PR TITLE
If there’s no Objective-C handler, invoke the JS callback anyway

### DIFF
--- a/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
+++ b/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
@@ -138,6 +138,23 @@ const NSTimeInterval timeoutSec = 5;
     }];
 }
 
+
+- (void)testJavascriptInvokeUndefinedHandler {
+    [self classSpecificTestJavascriptInvokeUndefinedHandler:_uiWebView];
+    [self classSpecificTestJavascriptInvokeUndefinedHandler:_wkWebView];
+    [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
+}
+- (void)classSpecificTestJavascriptInvokeUndefinedHandler:(id)webView {
+    WebViewJavascriptBridge *bridge = [self bridgeForWebView:webView];
+    loadEchoSample(webView);
+    XCTestExpectation *callbackInvocked = [self expectationWithDescription:@"Callback invoked"];
+    [bridge callHandler:@"jsInvokeUndefinedHandlerTest" data:nil responseCallback:^(id responseData) {
+        XCTAssertEqualObjects(responseData, @"Response from JS");
+        [callbackInvocked fulfill];
+    }];
+}
+
+
 - (void)testJavascriptReceiveResponseWithoutSafetyTimeout {
     [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_uiWebView];
     [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_wkWebView];

--- a/Tests/WebViewJavascriptBridgeTests/echo.html
+++ b/Tests/WebViewJavascriptBridgeTests/echo.html
@@ -27,6 +27,15 @@
 				}
 			})
 		})
+        bridge.registerHandler('jsInvokeUndefinedHandlerTest', function(data, responseCallback) {
+            bridge.callHandler('undefinedHandler', { foo:'bar' }, function(response) {
+                if (response && Object.keys(response).length == 0) {
+                    responseCallback("Response from JS")
+                } else {
+                    responseCallback("Failed")
+                }
+            })
+        })
 	})
 	</script>
 </body></html>

--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -147,6 +147,7 @@
             [_base logUnkownMessage:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
+        return;
     }
     
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -102,6 +102,7 @@ static int logMaxLength = 500;
             
             if (!handler) {
                 NSLog(@"WVJBNoHandlerException, No handler for message from JS: %@", message);
+                responseCallback(@{});
                 continue;
             }
             

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.h
@@ -1,3 +1,3 @@
 #import <Foundation/Foundation.h>
 
-NSString * WebViewJavascriptBridge_js();
+NSString * WebViewJavascriptBridge_js(void);


### PR DESCRIPTION
https://github.com/marcuswestin/WebViewJavascriptBridge/commit/6a11f45a9b69b577d9dd2d5e0e0c85021201045b#diff-bc11e5c0a6c9bc423b47e8e3c82da28cL105 stopped invoking the JavaScript callback when the native app doesn't implement a handler. This PR restores that behavior, making it possible for the JS code to detect this scenario and continue instead of waiting indefinitely for its callback to be invoked.
