### PR TITLE
Modify the Installation with CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation (iOS & OSX)
 Add this to your [podfile](https://guides.cocoapods.org/using/getting-started.html) and run `pod install` to install:
 
 ```ruby
-`pod 'WebViewJavascriptBridge', '~> 5.0'`
+pod 'WebViewJavascriptBridge', '~> 6.0'
 ```
 
 ### Manual installation


### PR DESCRIPTION
The 'Usage' describes the latest version 6.0.2 and the 'Installation with CocoaPods' installs the version 5.2.0. So, if someone follows the tutor,  the Objc will not connect with javascript. The reason is here https://github.com/marcuswestin/WebViewJavascriptBridge/issues/266#issuecomment-280273386 .

## Before your create your PR:

#### Please add tests for any new or changed functionality!

I have not modified any functionalities for your repo. What I have done is to modifying some infos in README.md.

Thanks.