### PR TITLE
fix WKWebViewJavascriptBridge to be equivalent to WebViewJavascriptBridge

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -148,8 +148,7 @@
         }
         decisionHandler(WKNavigationActionPolicyCancel);
     }
-    
-    if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
+    else if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
         [_webViewDelegate webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
     } else {
         decisionHandler(WKNavigationActionPolicyAllow);


### PR DESCRIPTION
When I test `WKWebViewJavascriptBridge`, sometimes external browser opens `https://__wvjb_queue_message__`.

After looking into the code, I've found `webView:decidePolicyForNavigationAction:decisionHandler:` of `WKWebViewJavascriptBridge` is not equivalent to https://github.com/marcuswestin/WebViewJavascriptBridge/blob/master/WebViewJavascriptBridge/WebViewJavascriptBridge.m#L136 or https://github.com/marcuswestin/WebViewJavascriptBridge/blob/master/WebViewJavascriptBridge/WebViewJavascriptBridge.m#L193

In case of `WKWebViewJavascriptBridge`, when `url` is "WebViewJavascriptBridgeURL", it is also passed to delegate now. I believe it is not desirable.