### PR TITLE
issue report

### DIFF
--- a/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
+++ b/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
@@ -67,7 +67,7 @@ const NSTimeInterval timeoutSec = 5;
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
 
-- (void)testEchoHandler {
+- (void)testEchoHandlerForiOS102 {
     // If you run on iOS 10.2, this test fails.
     [self classSpecificTestEchoHandler:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];

--- a/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
+++ b/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
@@ -66,6 +66,12 @@ const NSTimeInterval timeoutSec = 5;
     [self classSpecificTestEchoHandler:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
+
+- (void)testEchoHandler {
+    // If you run on iOS 10.2, this test fails.
+    [self classSpecificTestEchoHandler:_wkWebView];
+    [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
+}
 - (void)classSpecificTestEchoHandler:(id)webView {
     WebViewJavascriptBridge *bridge = [self bridgeForWebView:webView];
     


### PR DESCRIPTION
Hello,My Fridens

When I use the library for an app on an iOS 10.2 device, the app will crash with memory leak.
BTW, this crash will not appear on an iOS 10.2 simulator.

I am very anxious to wait for your solution . Thanks a lot

## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
