### PR TITLE
return after decisionHandler called to avoid call it more than once

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -147,6 +147,7 @@
             [_base logUnkownMessage:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
+        return;
     }
     
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {


### PR DESCRIPTION
in the latest version in [WKWebViewJavascriptBridge webView:decidePolicyForNavigationAction:decisionHandler:], after decisionHander executed:
```
    if ([_base isWebViewJavascriptBridgeURL:url]) {
        if ([_base isBridgeLoadedURL:url]) {
            [_base injectJavascriptFile];
        } else if ([_base isQueueMessageURL:url]) {
            [self WKFlushMessageQueue];
        } else {
            [_base logUnkownMessage:url];
        }
        decisionHandler(WKNavigationActionPolicyCancel);
    }
```
`decisionHandler` passed to `_webViewDelegate` and the delegate method may call `decisionHandler` again, most conditions it work well, but it leads crash on my iOS11+XCode9 beta environment. 
In my view, a decision cannot be made  for twice, the decisionHandler that consumed should not pass out side of this method, I hope this commit can fix it.