### PR TITLE
fix: pod version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation (iOS & OSX)
 Add this to your [podfile](https://guides.cocoapods.org/using/getting-started.html) and run `pod install` to install:
 
 ```ruby
-`pod 'WebViewJavascriptBridge', '~> 5.0'`
+pod 'WebViewJavascriptBridge'
 ```
 
 ### Manual installation


### PR DESCRIPTION
because 	`WVJBIframe.src = 'https://__bridge_loaded__';` is support 6.0 version, doesn't support 5.0 version.

## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
