### PR TITLE
Modified Custom URL Scheme Handling for WKWebView

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -147,10 +147,11 @@
             [_base logUnkownMessage:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
-    }
     
-    if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
+    } else if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
+        
         [_webViewDelegate webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
+    
     } else {
         decisionHandler(WKNavigationActionPolicyAllow);
     }


### PR DESCRIPTION
An WebViewJavascriptBridge-defined URL, like `wvjbscheme://__BRIDGE_LOADED__ ` should be only handled once. Because these URL only used in WebViewJavascriptBridge, we don't want to get these call in our `- webView:decidePolicyForNavigationAction:decisionHandler:`.

And it would also cause some other issues. see #296 , #298 

## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
