### PR TITLE
V5 Branch: Fix iOS 10.3.3 and iOS 11 crash

### DIFF
--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -148,9 +148,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
             [_base logUnkownMessage:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
-    }
-    
-    if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
+    } else if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {
         [_webViewDelegate webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
     } else {
         decisionHandler(WKNavigationActionPolicyAllow);


### PR DESCRIPTION
 Calls to the `decisionHandler()` block twice, resulting in iOS 10.3.3 and iOS 11 crash.
![wvbj_crash](https://user-images.githubusercontent.com/1787428/30647903-45b683d6-9e4f-11e7-87f0-59ec26914ebb.png)
