### PR TITLE
Fix  ReferenceError WebViewJavascriptBridge

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
@@ -128,7 +128,7 @@ NSString * WebViewJavascriptBridge_js() {
 		var callbacks = window.WVJBCallbacks;
 		delete window.WVJBCallbacks;
 		for (var i=0; i<callbacks.length; i++) {
-			callbacks[i](WebViewJavascriptBridge);
+			callbacks[i](window.WebViewJavascriptBridge);
 		}
 	}
 })();


### PR DESCRIPTION
Add missing window prefix to fix `ReferenceError: Can't find variable: WebViewJavascriptBridge`

After this little fix, the issue will become that `window.WebViewJavascriptBridge` is undefined, which is a little bit less cryptic.