### PR TITLE
fix: make sure callbacks will not be undefined.

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.m
@@ -125,7 +125,7 @@ NSString * WebViewJavascriptBridge_js() {
 	
 	setTimeout(_callWVJBCallbacks, 0);
 	function _callWVJBCallbacks() {
-		var callbacks = window.WVJBCallbacks;
+		var callbacks = window.WVJBCallbacks || [];
 		delete window.WVJBCallbacks;
 		for (var i=0; i<callbacks.length; i++) {
 			callbacks[i](WebViewJavascriptBridge);


### PR DESCRIPTION
Make sure callbacks will not be undefined so that setupWebViewJavascriptBridge can run only when needed.

Otherwise，a global error `undefined is not an object (evaluating 'callbacks.length')` happened.

Sorry for I don't have the environment to run test code~