### PR TITLE
Update WebViewJavascriptBridgeBase.m

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -78,8 +78,10 @@ static int logMaxLength = 500;
         NSString* responseId = message[@"responseId"];
         if (responseId) {
             WVJBResponseCallback responseCallback = _responseCallbacks[responseId];
-            responseCallback(message[@"responseData"]);
-            [self.responseCallbacks removeObjectForKey:responseId];
+            if (responseCallback) {
+                responseCallback(message[@"responseData"]);
+                [self.responseCallbacks removeObjectForKey:responseId];
+            }
         } else {
             WVJBResponseCallback responseCallback = NULL;
             NSString* callbackId = message[@"callbackId"];


### PR DESCRIPTION
If responseCallback is NULL, it will be crashed.The reason for this is that the method of using reset is incorrect.

## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
