### PR TITLE
fix crash in Swift project

### DIFF
--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -177,7 +177,7 @@
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
     if (webView != _webView) { return YES; }
-    
+    if (request == nil) { return YES; }
     NSURL *url = [request URL];
     __strong WVJB_WEBVIEW_DELEGATE_TYPE* strongDelegate = _webViewDelegate;
     if ([_base isWebViewJavascriptBridgeURL:url]) {


### PR DESCRIPTION
when delegate is written in swift, `return [strongDelegate webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];`will crash  due to a nil request.