### PR TITLE
Change the bridge URLs so that they can be used in a CSP. (Compatibility Version)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+machine:
+  xcode:
+    version: 9.0
+# dependencies:
+#   override:
+#     - brew install kylef/formulae/swiftenv
+#     - swiftenv install 3.0
+test:
+  override:
+    - make test-circle-ci

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ self.bridge = [WebViewJavascriptBridge bridgeForWebView:webView];
 4) Copy and paste `setupWebViewJavascriptBridge` into your JS:
 	
 ```javascript
-function setupWebViewJavascriptBridge(callback) {
+function setupWebViewJavascriptBridge(callback, forCSP=false) {
 	if (window.WebViewJavascriptBridge) { return callback(WebViewJavascriptBridge); }
 	if (window.WVJBCallbacks) { return window.WVJBCallbacks.push(callback); }
 	window.WVJBCallbacks = [callback];
 	var WVJBIframe = document.createElement('iframe');
-	WVJBIframe.style.display = 'none';
-	WVJBIframe.src = 'https://__bridge_loaded__';
+	WVJBIframe.style.display = 'none';                 
+	WVJBIframe.src = forCSP ? 'https://bridge-loaded' : 'https://__bridge_loaded__';
 	document.documentElement.appendChild(WVJBIframe);
 	setTimeout(function() { document.documentElement.removeChild(WVJBIframe) }, 0)
 }

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.h
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.h
@@ -11,6 +11,8 @@
 #define kNewProtocolScheme @"https"
 #define kQueueHasMessage   @"__wvjb_queue_message__"
 #define kBridgeLoaded      @"__bridge_loaded__"
+#define kQueueHasMessageNew @"wvjb-queue-message"
+#define kBridgeLoadedNew    @"bridge-loaded"
 
 typedef void (^WVJBResponseCallback)(id responseData);
 typedef void (^WVJBHandler)(id data, WVJBResponseCallback responseCallback);

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -136,12 +136,12 @@ static int logMaxLength = 500;
 
 - (BOOL)isQueueMessageURL:(NSURL*)url {
     NSString* host = url.host.lowercaseString;
-    return [self isSchemeMatch:url] && [host isEqualToString:kQueueHasMessage];
+    return [self isSchemeMatch:url] && ([host isEqualToString:kQueueHasMessage] || [host isEqualToString:kQueueHasMessageNew]);
 }
 
 - (BOOL)isBridgeLoadedURL:(NSURL*)url {
     NSString* host = url.host.lowercaseString;
-    return [self isSchemeMatch:url] && [host isEqualToString:kBridgeLoaded];
+    return [self isSchemeMatch:url] && ([host isEqualToString:kBridgeLoaded] || [host isEqualToString:kBridgeLoadedNew]);
 }
 
 - (void)logUnkownMessage:(NSURL*)url {


### PR DESCRIPTION
https://github.com/marcuswestin/WebViewJavascriptBridge/pull/264#issuecomment-342873077

```
Man, this is tricky.

On the one hand, this is clearly an improvement.

On the other hand, it's significant to ask everyone to fix up their code after an upgrade.

Is there any way to be automatically backwards compatible?
```

Addresses the compatibility issues mentioned by the author.
